### PR TITLE
fix(cask): SP-4454 match renamed macOS release artifacts for scanoss-…

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
 
       - name: Cache Homebrew Bundler RubyGems
         id: cache
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ${{ steps.set-up-homebrew.outputs.gems-path }}
           key: ${{ runner.os }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}

--- a/Casks/scanoss-code-compare.rb
+++ b/Casks/scanoss-code-compare.rb
@@ -1,73 +1,73 @@
 cask "scanoss-code-compare" do
-    version "0.13.3" # Updated by GitHub Actions
-    sha256 "3ddd722b6790a69e5b37d1fa005d07e2c47a63d1a803428280f72d76a57903c0" # Updated by GitHub Actions
+  version "0.13.3" # Updated by GitHub Actions
+  sha256 "3ddd722b6790a69e5b37d1fa005d07e2c47a63d1a803428280f72d76a57903c0" # Updated by GitHub Actions
 
-    url "https://github.com/scanoss/scanoss.cc/releases/download/v#{version}/scanoss-cc-mac.zip"
-    name "SCANOSS Code Compare"
-    desc "GUI and CLI tool for quickly visualizing undeclared open source findings"
-    homepage "https://github.com/scanoss/scanoss.cc"
+  url "https://github.com/scanoss/scanoss.cc/releases/download/v#{version}/scanoss-cc-mac.zip"
+  name "SCANOSS Code Compare"
+  desc "GUI and CLI tool for quickly visualizing undeclared open source findings"
+  homepage "https://github.com/scanoss/scanoss.cc"
 
-    depends_on macos: ">= :catalina"
+  depends_on macos: :catalina
+  container nested: "scanoss-cc-v#{version}.dmg"
 
-    container nested: "SCANOSS Code Compare-v#{version}.dmg"
-    app "SCANOSS Code Compare.app"
+  app "scanoss-cc.app", target: "SCANOSS Code Compare.app"
 
-    # Wrapper script that handles both GUI and CLI modes
-    postflight do
-      binary = "#{appdir}/SCANOSS Code Compare.app/Contents/MacOS/SCANOSS Code Compare"
-      shimscript = "#{staged_path}/scanoss-cc.wrapper.sh"
+  # Wrapper script that handles both GUI and CLI modes
+  postflight do
+    binary = "#{appdir}/SCANOSS Code Compare.app/Contents/MacOS/scanoss-cc"
+    shimscript = "#{staged_path}/scanoss-cc.wrapper.sh"
 
-      File.write shimscript, <<~EOS
-        #!/bin/bash
+    File.write shimscript, <<~EOS
+      #!/bin/bash
 
-        CURRENT_DIR=$(pwd)
+      CURRENT_DIR=$(pwd)
 
-        # Handle version flag directly
-        if [ "$1" = "--version" ] || [ "$1" = "-v" ]; then
-          exec "#{binary}" "$@"
-          exit 0
-        fi
+      # Handle version flag directly
+      if [ "$1" = "--version" ] || [ "$1" = "-v" ]; then
+        exec "#{binary}" "$@"
+        exit 0
+      fi
 
-        # If no arguments are provided, assume scanning mode and add --scan-root.
-        if [ "$#" -eq 0 ]; then
-          exec "#{binary}" --scan-root "$CURRENT_DIR"
-        fi
+      # If no arguments are provided, assume scanning mode and add --scan-root.
+      if [ "$#" -eq 0 ]; then
+        exec "#{binary}" --scan-root "$CURRENT_DIR"
+      fi
 
-        # If the first argument starts with a dash, assume scanning options.
-        first_arg="$1"
-        if [[ "$first_arg" == "-"* ]]; then
-          # Check if --scan-root is already provided.
-          found=0
-          for arg in "$@"; do
-            if [ "$arg" = "--scan-root" ]; then
-              found=1
-              break
-            fi
-          done
-          if [ $found -eq 0 ]; then
-            exec "#{binary}" --scan-root "$CURRENT_DIR" "$@"
-          else
-            exec "#{binary}" "$@"
+      # If the first argument starts with a dash, assume scanning options.
+      first_arg="$1"
+      if [[ "$first_arg" == "-"* ]]; then
+        # Check if --scan-root is already provided.
+        found=0
+        for arg in "$@"; do
+          if [ "$arg" = "--scan-root" ]; then
+            found=1
+            break
           fi
+        done
+        if [ $found -eq 0 ]; then
+          exec "#{binary}" --scan-root "$CURRENT_DIR" "$@"
         else
-          # Otherwise, assume subcommand mode and pass arguments as-is.
           exec "#{binary}" "$@"
         fi
-      EOS
+      else
+        # Otherwise, assume subcommand mode and pass arguments as-is.
+        exec "#{binary}" "$@"
+      fi
+    EOS
 
-      FileUtils.chmod "+x", shimscript
+    FileUtils.chmod "+x", shimscript
 
-      FileUtils.ln_sf shimscript, "#{HOMEBREW_PREFIX}/bin/scanoss-cc"
-    end
-
-    uninstall_postflight do
-      # Remove the CLI symlink on uninstall
-      FileUtils.rm "#{HOMEBREW_PREFIX}/bin/scanoss-cc" if File.exist? "#{HOMEBREW_PREFIX}/bin/scanoss-cc"
-    end
-
-    zap trash: [
-      "~/Library/Application Support/SCANOSS Code Compare",
-      "~/Library/Preferences/com.scanoss.code-compare.plist",
-      "~/Library/Saved Application State/com.scanoss.code-compare.savedState"
-    ]
+    FileUtils.ln_sf shimscript, "#{HOMEBREW_PREFIX}/bin/scanoss-cc"
   end
+
+  uninstall_postflight do
+    # Remove the CLI symlink on uninstall
+    FileUtils.rm("#{HOMEBREW_PREFIX}/bin/scanoss-cc") if File.symlink?("#{HOMEBREW_PREFIX}/bin/scanoss-cc")
+  end
+
+  zap trash: [
+    "~/Library/Application Support/SCANOSS Code Compare",
+    "~/Library/Preferences/com.wails.scanoss-cc.plist",
+    "~/Library/Saved Application State/com.wails.scanoss-cc.savedState",
+  ]
+end


### PR DESCRIPTION
…code-compare

The scanoss.cc release workflow renamed its artifacts (SP-3605): the zip now contains scanoss-cc-v<version>.dmg with scanoss-cc.app inside, but the cask still referenced the old "SCANOSS Code Compare" names, so install failed with:

  Error: No such file or directory @ rb_sysopen - .../SCANOSS Code Compare-v0.13.3.dmg

- point container/app/binary at the new artifact names
- keep the user-facing app name via target: "SCANOSS Code Compare.app"
- fix zap paths to the actual bundle id (com.wails.scanoss-cc)

Verified locally: install succeeds and `scanoss-cc --version` runs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated macOS installation and uninstall configuration to ensure proper application setup and system cleanup processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->